### PR TITLE
Add tasks to configure cron for cluster stats

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,3 +110,10 @@ clockwork_clusters:
     remote_path:
     # Interval between fetches (in minutes, for the */{interval} format)
     remote_interval:
+
+# Configuration for Cluster Stats cron
+# Define the interval to run the script (see field 'minute' in crontab(5))
+clockwork_clusterstats_cron_minute: '*/5'
+
+# Define the user who run the script. Optional, defaults to clockwork_user.
+#clockwork_clusterstats_cron_user:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -27,13 +27,17 @@
   tasks:
     - name: Setup MongoDB
       include_role:
-        name: clockwork
+        name: mila.clockwork
         tasks_from: setup_mongod
     - name: Setup clockwork server
       include_role:
-        name: clockwork
+        name: mila.clockwork
         tasks_from: setup_server
     - name: Setup clockwork scrape
       include_role:
-        name: clockwork
+        name: mila.clockwork
         tasks_from: setup_scrape
+    - name: Setup clockwork clusterstats cron
+      include_role:
+        name: mila.clockwork
+        tasks_from: setup_clusterstats_cron

--- a/tasks/setup_clusterstats_cron.yml
+++ b/tasks/setup_clusterstats_cron.yml
@@ -1,0 +1,18 @@
+- name: Checkout source code
+  ansible.builtin.include_role:
+    name: mila.clockwork
+    tasks_from: checkout_src
+
+- name: Configure path to Slurm commands in cron
+  ansible.builtin.cron:
+    name: PATH
+    env: yes
+    job: "/opt/slurm/bin:/usr/bin:/bin"
+    user: "{{ clockwork_clusterstats_cron_user | default(clockwork_user) }}"
+
+- name: Configure cron to execute Cluster Stats Cache script
+  ansible.builtin.cron:
+    name: "Generate Cluster Stats Cache"
+    job: "{{ clockwork_install_path }}/slurm_state/cron_scripts/generate_clusterstats_cache.sh"
+    minute: "{{ clockwork_clusterstats_cron_minute }}"
+    user: "{{ clockwork_clusterstats_cron_user | default(clockwork_user) }}"


### PR DESCRIPTION
Clockwork provides a cron script to collect cluster stats. Add a new
task file to configure the cron to execute this script.