### PR TITLE
fix: Do not display the clockwork private key

### DIFF
--- a/tasks/checkout_src.yml
+++ b/tasks/checkout_src.yml
@@ -9,6 +9,7 @@
     content: '{{ clockwork_git_deploy_key }}'
     dest: /root/clockwork_deploy
     mode: 0600
+  no_log: true
 
 - name: Copy clockwork code from git
   ansible.builtin.git:


### PR DESCRIPTION
Make sure ansible does not display the content of the private key
when ansible runs in diff or verbose mode.