### PR TITLE
adding three fields to clockwork.toml

### DIFF
--- a/templates/clockwork.toml.j2
+++ b/templates/clockwork.toml.j2
@@ -34,6 +34,12 @@ allocations="*"
 allocations={{ cluster.allocations }}
 {% endif %}
 timezone="{{ cluster.timezone }}"
+organization="{{ cluster.organization }}"
+nbr_cpus={{ cluster.nbr_cpus }}
+nbr_gpus={{ cluster.nbr_gpus }}
+official_documentation="{{ cluster.official_documentation }}"
+mila_documentation="{{ cluster.mila_documentation }}"
+display_order={{ cluster.display_order }}
 remote_user="{{ cluster.remote_user }}"
 remote_hostname="{{ cluster.remote_hostname }}"
 {% if cluster.sacct_enabled %}

--- a/templates/clockwork.toml.j2
+++ b/templates/clockwork.toml.j2
@@ -42,4 +42,6 @@ sacct_enabled={{ cluster.sacct_enabled }}
 sacct_enabled=false
 {% endif %}
 sacct_path="{{ cluster.sacct_path }}"
+sacct_ssh_key_filename="{{ cluster.sacct_ssh_key_filename }}"
+
 {% endfor %}

--- a/templates/clockwork.toml.j2
+++ b/templates/clockwork.toml.j2
@@ -34,24 +34,12 @@ allocations="*"
 allocations={{ cluster.allocations }}
 {% endif %}
 timezone="{{ cluster.timezone }}"
-{% endfor %}
-{% if cluster.remote_user %}
 remote_user="{{ cluster.remote_user }}"
-{% else %}
-remote_user=""
-{% endif %}
-{% if cluster.remote_hostname %}
 remote_hostname="{{ cluster.remote_hostname }}"
-{% else %}
-remote_hostname=""
-{% endif %}
-{% if cluster.remote_hostname %}
-remote_hostname="{{ cluster.remote_hostname }}"
-{% else %}
-remote_hostname=""
-{% endif %}
 {% if cluster.sacct_enabled %}
-sacct_enabled="{{ cluster.sacct_enabled }}"
+sacct_enabled={{ cluster.sacct_enabled }}
 {% else %}
 sacct_enabled=false
 {% endif %}
+sacct_path="{{ cluster.sacct_path }}"
+{% endfor %}

--- a/templates/clockwork.toml.j2
+++ b/templates/clockwork.toml.j2
@@ -42,11 +42,7 @@ mila_documentation="{{ cluster.mila_documentation }}"
 display_order={{ cluster.display_order }}
 remote_user="{{ cluster.remote_user }}"
 remote_hostname="{{ cluster.remote_hostname }}"
-{% if cluster.sacct_enabled %}
 sacct_enabled={{ cluster.sacct_enabled }}
-{% else %}
-sacct_enabled=false
-{% endif %}
 sacct_path="{{ cluster.sacct_path }}"
 sacct_ssh_key_filename="{{ cluster.sacct_ssh_key_filename }}"
 

--- a/templates/clockwork.toml.j2
+++ b/templates/clockwork.toml.j2
@@ -35,3 +35,23 @@ allocations={{ cluster.allocations }}
 {% endif %}
 timezone="{{ cluster.timezone }}"
 {% endfor %}
+{% if cluster.remote_user %}
+remote_user="{{ cluster.remote_user }}"
+{% else %}
+remote_user=""
+{% endif %}
+{% if cluster.remote_hostname %}
+remote_hostname="{{ cluster.remote_hostname }}"
+{% else %}
+remote_hostname=""
+{% endif %}
+{% if cluster.remote_hostname %}
+remote_hostname="{{ cluster.remote_hostname }}"
+{% else %}
+remote_hostname=""
+{% endif %}
+{% if cluster.sacct_enabled %}
+sacct_enabled="{{ cluster.sacct_enabled }}"
+{% else %}
+sacct_enabled=false
+{% endif %}


### PR DESCRIPTION
These fields are going to be used for calling sacct through SSH. These fields are already in the `hosts.yml` but they don't make it to `/etc/clockwork/clockwork.toml` at the moment and that means that we cannot use them. This commit will fix that.

This related to `cw204` branch of Clockwork, and in turn to `https://github.com/mila-iqia/clockwork/pull/88`.