### PR TITLE
lowercase for boolean values

### DIFF
--- a/templates/clockwork.toml.j2
+++ b/templates/clockwork.toml.j2
@@ -42,7 +42,7 @@ mila_documentation="{{ cluster.mila_documentation }}"
 display_order={{ cluster.display_order }}
 remote_user="{{ cluster.remote_user }}"
 remote_hostname="{{ cluster.remote_hostname }}"
-sacct_enabled={{ cluster.sacct_enabled }}
+sacct_enabled={{ cluster.sacct_enabled | lower}}
 sacct_path="{{ cluster.sacct_path }}"
 sacct_ssh_key_filename="{{ cluster.sacct_ssh_key_filename }}"
 


### PR DESCRIPTION
There's a problem at the moment with the fact that the boolean value "cluster.sacct_enabled" gets written with an uppercase in the toml scripts, and that's not even valid toml. This can be fixed with the ajustment of adding a `|lower` in the jinja2 template.

The consequence of this problem is that the deployment on `clockwork2-dev` is broken and needs to be adjusted manually by editing `/etc/clockwork/clockwork.toml`, which is not an acceptable solution. For this reason, and because this Ansible recipe is not used anywhere else, it's relatively safe to merge this into master and we could always backpedal if things break in practice (they're broken right now anyways).