### PR TITLE
dark_mode doesn't have a proper boolean for toml

### DIFF
--- a/templates/clockwork.toml.j2
+++ b/templates/clockwork.toml.j2
@@ -33,6 +33,7 @@ dark_mode=false
 language="{{ clockwork_settings_language }}"
 
 {% for cluster in clockwork_clusters %}
+
 [clusters.{{ cluster.name }}]
 account_field="{{ cluster.account_field }}"
 {% if cluster.update_field %}

--- a/templates/clockwork.toml.j2
+++ b/templates/clockwork.toml.j2
@@ -25,11 +25,14 @@ available_languages=["en", "fr"]
 
 [settings.default_values]
 nbr_items_per_page={{ clockwork_settings_items_per_page }}
-dark_mode={{ clockwork_settings_dark_mode }}
+{% if clockwork_settings_dark_mode %}
+dark_mode=true
+{% else %}
+dark_mode=false
+{% endif %}
 language="{{ clockwork_settings_language }}"
 
 {% for cluster in clockwork_clusters %}
-
 [clusters.{{ cluster.name }}]
 account_field="{{ cluster.account_field }}"
 {% if cluster.update_field %}


### PR DESCRIPTION
The current state of things leads to a file `/etc/clockwork/clockwork.toml` with the following invalid toml data because of the `False` value. It should be `false`.

```
[settings.default_values]
nbr_items_per_page=25
dark_mode=False
language="en"
```