### PR TITLE
Adding logging levels in config

### DIFF
--- a/templates/clockwork.toml.j2
+++ b/templates/clockwork.toml.j2
@@ -9,8 +9,11 @@ traces_sample_rate={{ clockwork_sentry_traces_sample_rate }}
 
 [logging]
 level="{{ clockwork_logging_level }}"
+level_stderr="{{ clockwork_logging_level_stderr }}"
+level_werkzeug="{{ clockwork_logging_level_werkzeug }}"
 stderr=false
 journald=true
+
 
 [google]
 client_id="{{ clockwork_google_client_id }}"


### PR DESCRIPTION
This relates to this PR : https://github.com/mila-iqia/clockwork/pull/114

The integration of the `logging` module involves adding two more variables in the configuration. These cannot be added to `clockwork.toml.append.j2` because they belong to an existing section already.

Those variables have already been added to commit https://github.com/mila-iqia/clockwork-debarras/commit/358f8750e3d5bed403244cc26b5573fc8cf6b195 to have the variables in `hosts.yml`.