### PR TITLE
Increase buffer size

### DIFF
--- a/templates/uwsgi.ini.j2
+++ b/templates/uwsgi.ini.j2
@@ -9,3 +9,5 @@ chmod-socket = 660
 vaccum = true
 
 die-on-term = true
+
+buffer-size = 8192


### PR DESCRIPTION
Increase the buffer size set in uwsgi.ini to 8192.
This is done after some 502 errors while trying to connect