### PR TITLE
Install scripts requirements from the setup_users task

### DIFF
--- a/tasks/setup_users.yml
+++ b/tasks/setup_users.yml
@@ -1,4 +1,10 @@
 ---
+# We can immediately install requirements from the file {{ clockwork_install_path }}/scripts/requirements.txt
+# because it is expected that this task is called after setup_scrape, which copy the source code
+- name: Install scripts requirements with pip
+  ansible.builtin.pip:
+    requirements: "{{ clockwork_install_path }}/scripts/requirements.txt"
+
 - name: Setup user update scripts
   ansible.builtin.template:
     src: templates/clockwork-users.service.j2


### PR DESCRIPTION
This is done because the users import is based on scripts